### PR TITLE
fix(playlist): include primary_color type on playlist interface

### DIFF
--- a/src/interfaces/Spotify/Playlist.ts
+++ b/src/interfaces/Spotify/Playlist.ts
@@ -45,6 +45,7 @@ export interface Playlist {
   images: Image[];
   name: string;
   owner: UserPublic;
+  primary_color: string | null;
   public: boolean;
   snapshot_id: string;
   tracks: PagingObject<PlaylistTrack>;


### PR DESCRIPTION
The top level `Playlist` type can include a `primary_color` field

<img width="315" alt="image" src="https://user-images.githubusercontent.com/9088799/208946838-000cd2f3-5216-4a03-8fea-9a55dd85542a.png">
