### PR TITLE
fix(playlist): omit internal property from featured playlist api

### DIFF
--- a/src/interfaces/Spotify/Playlist.ts
+++ b/src/interfaces/Spotify/Playlist.ts
@@ -53,6 +53,5 @@ export interface Playlist {
 }
 
 export interface FeaturedPlaylist {
-  message: string;
   playlists: PagingObject<SimplifiedPlaylist>;
 }

--- a/src/lib/playlist/PlaylistManager.ts
+++ b/src/lib/playlist/PlaylistManager.ts
@@ -214,6 +214,11 @@ export class PlaylistManager extends Manager {
       }
     });
 
-    return res.data as FeaturedPlaylist;
+    // `message` is a property used internally by the Spotify API.
+    // It is not a part of the official documented API response and should not be returned.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { message, ...featuredPlaylist } = res.data;
+
+    return featuredPlaylist as FeaturedPlaylist;
   }
 }

--- a/src/lib/playlist/PlaylistManager.ts
+++ b/src/lib/playlist/PlaylistManager.ts
@@ -214,11 +214,6 @@ export class PlaylistManager extends Manager {
       }
     });
 
-    // `message` is a property used internally by the Spotify API.
-    // It is not a part of the official documented API response and should not be returned.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { message, ...featuredPlaylist } = res.data;
-
-    return featuredPlaylist as FeaturedPlaylist;
+    return res.data as FeaturedPlaylist;
   }
 }


### PR DESCRIPTION
Based off #54 , we should not be including properties in the response type that do not have official documentation by Spotify.

This PR omits the `message` property from the `FeaturedPlaylist` type as it isn't documented in the Featured Playlist API ([ref](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-featured-playlists))